### PR TITLE
Allows multiple recipients using Mandrill Adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Gemfile.lock
+tags

--- a/lib/monkey-mailer/adapters/mandrilapi.rb
+++ b/lib/monkey-mailer/adapters/mandrilapi.rb
@@ -69,7 +69,9 @@ module MonkeyMailer
         end
 
         recipients.each_with_index do |recipient, idx|
-          to_list << { "email" => recipient.strip, "name" => names[idx].strip, "type" => type.to_s }
+          to_list << { "email" => recipient.strip,
+                       "name" => names[idx] ? names[idx].strip : "",
+                       "type" => type.to_s }
         end
 
         to_list

--- a/lib/monkey-mailer/adapters/mandrilapi.rb
+++ b/lib/monkey-mailer/adapters/mandrilapi.rb
@@ -18,10 +18,7 @@ module MonkeyMailer
         request_body = {
           :key => @key,
           :message => {
-            :to => [{
-              :email => email.to_email,
-              :name => email.to_name
-            }],
+            :to => parse_recipients(email.to_email, email.to_name),
             :from_name => email.from_name,
             :from_email => email.from_email,
             :subject => email.subject,
@@ -59,6 +56,25 @@ module MonkeyMailer
         raise MonkeyMailer::DeliverError.new("Mandril response.code not equal to 200") unless response.code.to_i == 200
         puts "Response #{response.code} #{response.message}: #{response.body}"
       end
+
+      def parse_recipients(recipients_list, names_list = "", type = :to)
+        recipients = recipients_list.split(",")
+        names      = names_list.split(",")
+        to_list    = []
+
+        raise RuntimeError.new("No recipients specified") if recipients.empty?
+
+        if names.any? && (names.count != recipients.count)
+          raise RuntimeError.new("Recipients and Names lists don't match")
+        end
+
+        recipients.each_with_index do |recipient, idx|
+          to_list << { "email" => recipient.strip, "name" => names[idx].strip, "type" => type.to_s }
+        end
+
+        to_list
+      end
+
     end
   end
 end

--- a/lib/monkey-mailer/adapters/mandrilapi.rb
+++ b/lib/monkey-mailer/adapters/mandrilapi.rb
@@ -57,7 +57,7 @@ module MonkeyMailer
         puts "Response #{response.code} #{response.message}: #{response.body}"
       end
 
-      def parse_recipients(recipients_list, names_list = "", type = :to)
+      def parse_recipients(recipients_list, names_list = "")
         recipients = recipients_list.split(",")
         names      = names_list.to_s.split(",")
         to_list    = []
@@ -71,7 +71,7 @@ module MonkeyMailer
         recipients.each_with_index do |recipient, idx|
           to_list << { "email" => recipient.strip,
                        "name" => names[idx] ? names[idx].strip : "",
-                       "type" => type.to_s }
+                       "type" => "to" }
         end
 
         to_list

--- a/lib/monkey-mailer/adapters/mandrilapi.rb
+++ b/lib/monkey-mailer/adapters/mandrilapi.rb
@@ -18,10 +18,7 @@ module MonkeyMailer
         request_body = {
           :key => @key,
           :message => {
-            :to => [{
-              :email => email.to_email,
-              :name => email.to_name
-            }],
+            :to => parse_recipients(email.to_email, email.to_name),
             :from_name => email.from_name,
             :from_email => email.from_email,
             :subject => email.subject,
@@ -59,6 +56,25 @@ module MonkeyMailer
         raise MonkeyMailer::DeliverError.new("Mandril response.code not equal to 200") unless response.code.to_i == 200
         puts "Response #{response.code} #{response.message}: #{response.body}"
       end
+
+      def parse_recipients(recipients_list, names_list = "", type = :to)
+        recipients = recipients_list.split(",")
+        names      = names_list.to_s.split(",")
+        to_list    = []
+
+        raise RuntimeError.new("No recipients specified") if recipients.empty?
+
+        if names.any? && (names.count != recipients.count)
+          raise RuntimeError.new("Recipients and Names lists don't match")
+        end
+
+        recipients.each_with_index do |recipient, idx|
+          to_list << { "email" => recipient.strip, "name" => names[idx].strip, "type" => type.to_s }
+        end
+
+        to_list
+      end
+
     end
   end
 end

--- a/spec/mandrill_adapter_spec.rb
+++ b/spec/mandrill_adapter_spec.rb
@@ -1,0 +1,36 @@
+require_relative 'spec_helper'
+
+describe 'Mandrill Adapter' do
+  before do
+    @adapter = MonkeyMailer::Adapters::MandrilAPI.new({})
+  end
+
+  it 'should parse recipients' do
+    recipients = "eddie@pj.com, jeff@pj.com, mike@pj.com, stone@pj.com, matt@pj.com"
+
+    names = "Eddie, Jeff, Mike, Stone, Matt"
+
+    to_field = @adapter.parse_recipients(recipients, names)
+
+    to_field.should include({ "email" => "eddie@pj.com", "name" => "Eddie", "type" => "to" })
+    to_field.should include({ "email" => "jeff@pj.com", "name" => "Jeff", "type" => "to" })
+    to_field.should include({ "email" => "mike@pj.com", "name" => "Mike", "type" => "to" })
+    to_field.should include({ "email" => "stone@pj.com", "name" => "Stone", "type" => "to" })
+    to_field.should include({ "email" => "matt@pj.com", "name" => "Matt", "type" => "to" })
+  end
+
+  it 'should not allow an empty recipients list' do
+    expect {
+      @adapter.parse_recipients("")
+    }.to raise_error(RuntimeError, "No recipients specified")
+  end
+
+  it 'should not allow unmatched emails and names lists' do
+    recipients = "eddie@pj.com,jeff@pj.com"
+    names = "Eddie,Jeff,Stone"
+
+    expect {
+      @adapter.parse_recipients(recipients, names)
+    }.to raise_error(RuntimeError, "Recipients and Names lists don't match")
+  end
+end


### PR DESCRIPTION
This PR allows specifying multiple recipients in a comma separated list by parsing them to the format expected by [Mandrill API](https://mandrillapp.com/api/docs/messages.JSON.html):

```
"to": [
            {
                "email": "recipient.email@example.com",
                "name": "Recipient Name",
                "type": "to"
            }
        ],
```

It allows an empty names list, but if you specify one, it must match the length of the recipients list.
It only allows `to` recipient type, however, as Mandrill hides the the rest of the recipients, I think it's not a big deal.
